### PR TITLE
destacando h3

### DIFF
--- a/active_handout/assets/css/devlife.css
+++ b/active_handout/assets/css/devlife.css
@@ -99,6 +99,13 @@ body {
   margin: 4rem 0 1rem;
 }
 
+.md-typeset.md-typeset h3 {
+  color: #404040;
+  font-family: "Source Sans Pro", sans-serif;
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+
 .md-typeset.md-typeset p {
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
Oi @toshikurauchi proposta para destacar melhor o `### subsubsection`. Eu segui o padrão do `h2` com uma fonte um pouco menor (tamanho padrão do material).